### PR TITLE
Update overlay_loader.dart

### DIFF
--- a/lib/overlay_loader.dart
+++ b/lib/overlay_loader.dart
@@ -8,7 +8,9 @@ Future<dynamic> overlayLoader({
   Color opacityColor = Colors.black,
   num opacity = .5,
 }) async {
-  OverlayState overlayState = Overlay.of(context);
+  final navigatorState = Navigator.of(context, rootNavigator: false);
+  final overlayState = navigatorState.overlay;
+  
   OverlayEntry overlayEntryOpacity = OverlayEntry(
     builder: (context) {
       return Opacity(


### PR DESCRIPTION
Hi Brian, in those two years Overlay has changed a bit.
The changes made in 2020 to prevent the reconstruction of all MaterialApp in pop placed it below the navigation stack.
Because of this, it is not possible to display an overlay with this library using a context above the NavigatorState child overlay widget.
It would be good to support the top level context, because in addition to allowing contextless navigation through a NavigatorKey, it allows you to use the widget context that includes the MaterialApp to display an overlay.